### PR TITLE
Simplify ad mode detection logic

### DIFF
--- a/content.js
+++ b/content.js
@@ -184,9 +184,9 @@ async function speak(text, clear) {
   chrome.runtime.onMessage.addListener((msg) => {
     console.log('onMessage: msg', msg);
     switch (msg?.type) {
-      case 'AD_SEGMENT_DETECTED': {
-        // First ad segment fetched; playback will switch soon
-        speak('Ad segment detected', false);
+      case 'PROGRAM_MODE_AD_SEGMENT': {
+        const index = Number.isFinite(msg.index) ? msg.index : 0;
+        speak(`Ad segment ${index}`, false);
         break;
       }
       case "AD_START": {
@@ -207,9 +207,9 @@ async function speak(text, clear) {
         speak('Program bumper detected', false);
         break;
       }
-      case 'PROG_SEGMENT_DETECTED': {
-        // First program segment fetched during an ad; resume soon
-        speak('Program segment detected', false);
+      case 'AD_MODE_PROGRAM_SEGMENT': {
+        const index = Number.isFinite(msg.index) ? msg.index : 0;
+        speak(`Program segment ${index}`, false);
         break;
       }
       case "PROGRAM": {

--- a/content.js
+++ b/content.js
@@ -207,6 +207,11 @@ async function speak(text, clear) {
         speak('Program bumper detected', false);
         break;
       }
+      case 'AD_MODE_PROGRAM_BUMPER': {
+        const index = Number.isFinite(msg.index) ? msg.index : 0;
+        speak(`Program bumper ${index}`, false);
+        break;
+      }
       case 'AD_MODE_PROGRAM_SEGMENT': {
         const index = Number.isFinite(msg.index) ? msg.index : 0;
         speak(`Program segment ${index}`, false);


### PR DESCRIPTION
## Summary
- replace the timing-based scheduling with simple counter thresholds for entering/exiting ad mode
- add ad/program segment counters and reset logic tied to the new thresholds
- drop the old segment duration measurement helpers that are no longer used

## Testing
- not run (extension has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c90a8aa94c8333beefd69f1f46843e